### PR TITLE
Support transitions without `from:`

### DIFF
--- a/lib/aasm/graph/cli.rb
+++ b/lib/aasm/graph/cli.rb
@@ -18,7 +18,14 @@ module AASM
           end
           klass.aasm.events.each do |event|
             event.transitions.each do |transition|
-              edges << "#{transition.from} -> #{transition.to} [ label = \"#{event.name}\" ];\n"
+              if transition.from
+                edges << "#{transition.from} -> #{transition.to} [ label = \"#{event.name}\" ];\n"
+              else
+                # for transitions with omitted `from`
+                klass.aasm.states.each do |state|
+                  edges << "#{state} -> #{transition.to} [ label = \"#{event.name}\" ];\n"
+                end
+              end
             end
           end
 


### PR DESCRIPTION
# Context
It is possible to have `transistions` omitting the `from:`, but it is not supported by this gem yet.
- https://github.com/aasm/aasm#transitions

# Changes
- Create new edge from all declared states when `from:` is omitted

